### PR TITLE
Disable pull up on TMOSI upon disableSpiPins()

### DIFF
--- a/dw-link/dw-link.ino
+++ b/dw-link/dw-link.ino
@@ -3351,6 +3351,7 @@ void enableSpiPins () {
 void disableSpiPins () {
   digitalWrite(pm.TISP, HIGH);
   pinMode(pm.TSCK, INPUT); 
+  digitalWrite(pm.TMOSI, LOW); // disable pull up
   pinMode(pm.TMOSI, INPUT);
   pinMode(pm.TMISO, INPUT);
 }


### PR DESCRIPTION
The pull up interferes with normal operation of the target's corresponding pin.